### PR TITLE
Bump from LTS 14.17 to LTS 19.6

### DIFF
--- a/aws-ec2-knownhosts.cabal
+++ b/aws-ec2-knownhosts.cabal
@@ -22,17 +22,17 @@ library
                  , AWS.PubKeys
                  , AWS.Types
 
-  build-depends: base        >= 4.7   && < 4.13
-               , aeson       >= 1.0   && < 1.5
+  build-depends: base        >= 4.7   && < 4.16
+               , aeson       >= 1.0   && < 2.1
                , async       >= 2.0   && < 2.3
-               , attoparsec  >= 0.12  && < 0.14
+               , attoparsec  >= 0.12  && < 0.15
                , bytestring  >= 0.10  && < 0.11
                , directory   >= 1.2   && < 1.4
                , filepath    >= 1.4   && < 1.5
                , io-streams  >= 1.3.4 && < 1.6
                , process     >= 1.4   && < 1.7
                , text        >= 1.1   && < 1.3
-               , text-format >= 0.3   && < 0.4
+               , text-format >= 0.3.3   && < 0.4
 
 
 executable aws-ec2-pubkeys
@@ -41,7 +41,7 @@ executable aws-ec2-pubkeys
   default-language:  Haskell2010
   ghc-options:       -threaded -Wall -fwarn-tabs -funbox-strict-fields -O2 -rtsopts
 
-  build-depends: base               >= 4.7 && < 4.13
+  build-depends: base               >= 4.7 && < 4.16
                , aws-ec2-knownhosts
                , io-streams         >= 1.1 && < 1.6
                , system-filepath    >= 0.4 && < 0.5
@@ -54,8 +54,8 @@ executable aws-ec2-knownhosts
   default-language:  Haskell2010
   ghc-options:       -threaded -Wall -fwarn-tabs -funbox-strict-fields -O2 -rtsopts
 
-  build-depends: base               >= 4.7 && < 4.13
-               , aeson              >= 1.0 && < 1.5
+  build-depends: base               >= 4.7 && < 4.16
+               , aeson              >= 1.0 && < 2.1
                , aws-ec2-knownhosts
                , io-streams         >= 1.1 && < 1.6
                , system-filepath    >= 0.4 && < 0.5
@@ -68,8 +68,8 @@ executable aws-ec2-keysync
   default-language:  Haskell2010
   ghc-options:       -threaded -Wall -fwarn-tabs -funbox-strict-fields -O2 -rtsopts
 
-  build-depends: base               >= 4.7 && < 4.13
-               , aeson              >= 1.0 && < 1.5
+  build-depends: base               >= 4.7 && < 4.16
+               , aeson              >= 1.0 && < 2.1
                , aws-ec2-knownhosts
                , io-streams         >= 1.1 && < 1.6
                , system-filepath    >= 0.4 && < 0.5

--- a/exec/aws-ec2-keysync/Main.hs
+++ b/exec/aws-ec2-keysync/Main.hs
@@ -7,7 +7,6 @@ import           Data.Aeson                   (Result (..), fromJSON, json')
 import           Data.Bool                    (bool)
 import           Data.Function                (on)
 import           Data.List                    (foldl')
-import           Data.Monoid                  ((<>))
 import           Filesystem.Path.CurrentOS    (encodeString, fromText)
 import           Prelude                      hiding (FilePath)
 import qualified System.IO.Streams            as Streams

--- a/exec/aws-ec2-knownhosts/Main.hs
+++ b/exec/aws-ec2-knownhosts/Main.hs
@@ -3,7 +3,6 @@
 module Main where
 
 import           Data.Aeson                   (Result (..), fromJSON, json)
-import           Data.Maybe                   (maybe)
 import           Filesystem.Path.CurrentOS    (encodeString)
 import           Prelude                      hiding (FilePath)
 import qualified System.IO.Streams            as Streams

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,10 @@
-resolver: lts-14.17
+resolver: lts-19.6
 flags: {}
 packages:
   - '.'
-extra-deps: []
+extra-deps:
+  # There is an open PR to get text-format compiling on GHC-9:
+  # https://github.com/hackage-trustees/text-format/pull/3
+  # This is the repo/commit from that PR.
+  - git: https://github.com/oliverbunting/text-format.git
+    commit: eded7ae45ae985673fa0902ba622ccd95e66728e

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,10 +3,21 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    name: text-format
+    pantry-tree:
+      sha256: fac733f9363ae03a3df48c151d9ad15cb148fe5c3c407821d7f241b3ad1d00af
+      size: 1273
+    commit: eded7ae45ae985673fa0902ba622ccd95e66728e
+    git: https://github.com/oliverbunting/text-format.git
+    version: 0.3.3
+  original:
+    commit: eded7ae45ae985673fa0902ba622ccd95e66728e
+    git: https://github.com/oliverbunting/text-format.git
 snapshots:
 - completed:
-    sha256: 1d72b33c0fc048e23f4f18fd76a6ad79dd1d8a3c054644098a71a09855e40c7c
-    size: 524799
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/17.yaml
-  original: lts-14.17
+    sha256: fb634b19f31da06684bb07ce02a20c75a3162138f279b388905b03ebd57bb50f
+    size: 618876
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/6.yaml
+  original: lts-19.6


### PR DESCRIPTION
It looks like #7 wasn't correctly based on `master`.  This PR is the same code as #7, but correctly based on `master`.

Checkout #7 for a little discussion about this.