### PR TITLE
Replace turtle

### DIFF
--- a/aws-ec2-knownhosts.cabal
+++ b/aws-ec2-knownhosts.cabal
@@ -43,7 +43,7 @@ executable aws-ec2-pubkeys
   build-depends: base               >= 4.7 && < 5
                , aws-ec2-knownhosts
                , io-streams         >= 1.1 && < 1.6
-               , optparse-applicative >= 0.17 && < 1.0
+               , optparse-applicative >= 0.16 && < 0.18
 
 
 executable aws-ec2-knownhosts
@@ -56,7 +56,7 @@ executable aws-ec2-knownhosts
                , aeson              >= 1.0 && < 2.1
                , aws-ec2-knownhosts
                , io-streams         >= 1.1 && < 1.6
-               , optparse-applicative >= 0.17 && < 1.0
+               , optparse-applicative >= 0.16 && < 0.18
 
 
 executable aws-ec2-keysync
@@ -70,7 +70,7 @@ executable aws-ec2-keysync
                , aws-ec2-knownhosts
                , io-streams         >= 1.1 && < 1.6
                , text               >= 1.0 && < 2.1
-               , optparse-applicative >= 0.17 && < 1.0
+               , optparse-applicative >= 0.16 && < 0.18
                , directory          >= 1.3 && < 1.4
                , unix-compat        >= 0.4 && < 0.7
                , process            >= 1.0 && < 1.7

--- a/aws-ec2-knownhosts.cabal
+++ b/aws-ec2-knownhosts.cabal
@@ -69,5 +69,8 @@ executable aws-ec2-keysync
                , aeson              >= 1.0 && < 2.1
                , aws-ec2-knownhosts
                , io-streams         >= 1.1 && < 1.6
-               , system-filepath    >= 0.4 && < 0.5
-               , turtle             >= 1.3 && < 1.6
+               , text               >= 1.0 && < 2.1
+               , optparse-applicative >= 0.17 && < 1.0
+               , directory          >= 1.3 && < 1.4
+               , unix-compat        >= 0.4 && < 0.7
+               , process            >= 1.0 && < 1.7

--- a/aws-ec2-knownhosts.cabal
+++ b/aws-ec2-knownhosts.cabal
@@ -43,8 +43,7 @@ executable aws-ec2-pubkeys
   build-depends: base               >= 4.7 && < 5
                , aws-ec2-knownhosts
                , io-streams         >= 1.1 && < 1.6
-               , system-filepath    >= 0.4 && < 0.5
-               , turtle             >= 1.3 && < 1.6
+               , optparse-applicative >= 0.17 && < 1.0
 
 
 executable aws-ec2-knownhosts

--- a/aws-ec2-knownhosts.cabal
+++ b/aws-ec2-knownhosts.cabal
@@ -57,8 +57,7 @@ executable aws-ec2-knownhosts
                , aeson              >= 1.0 && < 2.1
                , aws-ec2-knownhosts
                , io-streams         >= 1.1 && < 1.6
-               , system-filepath    >= 0.4 && < 0.5
-               , turtle             >= 1.3 && < 1.6
+               , optparse-applicative >= 0.17 && < 1.0
 
 
 executable aws-ec2-keysync

--- a/exec/aws-ec2-knownhosts/Main.hs
+++ b/exec/aws-ec2-knownhosts/Main.hs
@@ -5,29 +5,34 @@ module Main where
 import AWS.KnownHosts (updateKnownHosts)
 import AWS.Types (Ec2Instance (..))
 import Data.Aeson (Result (..), fromJSON, json)
-import Filesystem.Path.CurrentOS (encodeString)
 import qualified System.IO.Streams as Streams
 import System.IO.Streams.Attoparsec (parseFromStream)
-import Turtle (FilePath, Parser, argPath, options)
-import Prelude hiding (FilePath)
+import Options.Applicative (Parser)
+import qualified Options.Applicative as Opt
 
 
 main :: IO ()
-main =
-    options "Update known_hosts file with pubkeys from EC2" args
-        >>= readKeys
-        >>= maybe noKeys updateKnownHosts
+main = do
+  Opt.execParser opts
+    >>= readKeys
+    >>= maybe noKeys updateKnownHosts
+  where
+    opts = Opt.info (Opt.helper <*> args)
+        $ Opt.fullDesc
+            <> Opt.progDesc "Update known_hosts file with pubkeys from EC2"
+            <> Opt.header "aws-ec2-knownhosts - Get EC2 pubkeys on your known_hosts file"
 
 
 args :: Parser FilePath
-args = argPath "pubkey_file" "Path to JSON pubkey file to update knownhosts"
+args =
+  Opt.strArgument $
+    Opt.metavar "PUBKEY_FILE" <> Opt.help "Path to JSON pubkey file to update knownhosts"
 
 
 readKeys :: FilePath -> IO (Maybe [Ec2Instance])
 readKeys =
     fmap (maybeResult . fromJSON)
         . flip Streams.withFileAsInput (parseFromStream json)
-        . encodeString
 
 
 maybeResult :: Result a -> Maybe a

--- a/exec/aws-ec2-pubkeys/Main.hs
+++ b/exec/aws-ec2-pubkeys/Main.hs
@@ -4,21 +4,26 @@ module Main where
 
 import AWS.PubKeys (getPubKeys, instanceParser, writePubKeys)
 import AWS.Types (Ec2Instance (..))
-import Filesystem.Path.CurrentOS (encodeString)
 import qualified System.IO.Streams as Streams
 import System.IO.Streams.Attoparsec (parseFromStream)
-import Turtle (Parser, argPath, options)
+import Options.Applicative (Parser)
+import qualified Options.Applicative as Opt
 
 
 main :: IO ()
-main = options "Get SSH pubkeys from EC2" args >>= processPubKeys
+main = Opt.execParser opts >>= processPubKeys
+  where
+    opts = Opt.info (Opt.helper <*> args)
+      $ Opt.fullDesc
+          <> Opt.progDesc "Get SSH pubkeys from EC2 instances as a JSON file"
+          <> Opt.header "aws-ec2-pubkeys - Get SSH pubkeys from EC2"
 
 
 args :: Parser (FilePath, FilePath)
 args =
     (,)
-        <$> (encodeString <$> argPath "instance_file" "File with information about EC2 hosts")
-        <*> (encodeString <$> argPath "pubkey_file" "Path to JSON pubkey file to output")
+        <$> Opt.strArgument (Opt.metavar "INSTANCE_FILE" <> Opt.help "File with information about EC2 hosts")
+        <*> Opt.strArgument (Opt.metavar "PUBKEY_FILE" <> Opt.help "Path to JSON pubkey file to output")
 
 
 -- TODO Implement a function to poll until all pubkeys are available


### PR DESCRIPTION
This uses `optparse-applicative` instead of `turtle` for parsing arguments, `process` for executing programs (calls to `aws s3`) and `directory` for operations with the file system (used for deleting a directory in the keysync executable).

Everything continues to work the same, I've tested with an EC2 instance in our environment and ensured it continues to work for our common workflow, that is:

- Used `aws-ec2-pubkeys` to download keys from the instance using the provided `aws-ec2-instances.json` file. While the key is not yet available it gives a parsing error which is consistent with the actual behavior of the tool, so no actual changes in functionality.
- Used `aws-ec2-knownhosts` and verified it updates keys in the `~/.ssh/known_hosts` file.
- Used `aws-ec2-keysync` and ensured it is able to download the existing keys file from S3, merge the new key in, and pushes to S3 the updated `aws-ec2-pubkeys.json` file.

Fixes #14 