### PR TITLE
Make sure hie.yaml has the correct commonent names for aws-ec2-knownhosts and -keysync

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -6,7 +6,7 @@ cradle:
 
     - component: "aws-ec2-knownhosts:exe:aws-ec2-pubkeys"
       path: "./exec/aws-ec2-pubkeys"
-    - component: "aws-ec2-knownhosts:exe:knownhosts"
+    - component: "aws-ec2-knownhosts:exe:aws-ec2-knownhosts"
       path: "./exec/aws-ec2-knownhosts"
-    - component: "aws-ec2-knownhosts:exe:keysync"
+    - component: "aws-ec2-knownhosts:exe:aws-ec2-keysync"
       path: "./exec/aws-ec2-keysync"


### PR DESCRIPTION
Update the component names in the hie.yaml file.

I needed this in order to have `haskell-language-server` run correctly when I ran it on the command line.
