### PR TITLE
On Nitro-based instances, access serial logs directly

### DIFF
--- a/src/AWS/PubKeys.hs
+++ b/src/AWS/PubKeys.hs
@@ -61,7 +61,7 @@ getPubKey inst = tryJust handler $ do
     keytype' = "ecdsa-sha2-nistp256"
     command =
         printf
-            "aws ec2 get-console-output --region %s --output text --instance-id %s"
+            "aws ec2 get-console-output --region %s --latest --output text --instance-id %s"
             (region inst)
             (instanceId inst)
 


### PR DESCRIPTION
Accessing console logs by the default method is slow, as it can take up to 15 minutes for the output to appear.

Nitro-based instances have a feature that allows querying the serial log directly, which updates much more quickly. https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/troubleshoot-unreachable-instance.html#instance-console-console-output

This has been tested by causing all instances in dev to be replaced, and re-querying their host keys. All hosts responded within two queries.

It is not clear what the fallback behaviour of this switch is when applied to a non-Nitro instance, as we have no such instances to test with. Ideally it would revert to the old behaviour, if not we may need to add a command-line flag to support older instances, or clarify that this feature only works on Nitro hosts.

If possible, please merge preserving the commit ID, or update the PR here to reflect the correct HEAD commit: https://github.com/bitnomial/bitnomial/pull/6253