### PR TITLE
Updated stack resolver to LTS-22.x, updated cabal dependency bounds

### DIFF
--- a/aws-ec2-knownhosts.cabal
+++ b/aws-ec2-knownhosts.cabal
@@ -45,7 +45,7 @@ executable aws-ec2-pubkeys
   build-depends: base                 >= 4.7  && < 5
                , aws-ec2-knownhosts
                , io-streams           >= 1.1  && < 1.6
-               , optparse-applicative >= 0.16 && < 0.18
+               , optparse-applicative >= 0.16 && < 0.19
                , text                 >= 2.0  && < 2.3
 
 
@@ -59,7 +59,7 @@ executable aws-ec2-knownhosts
                , aeson                >= 2.0  && < 2.3
                , aws-ec2-knownhosts
                , io-streams           >= 1.1  && < 1.6
-               , optparse-applicative >= 0.16 && < 0.18
+               , optparse-applicative >= 0.16 && < 0.19
 
 
 executable aws-ec2-keysync
@@ -73,7 +73,7 @@ executable aws-ec2-keysync
                , aws-ec2-knownhosts
                , io-streams           >= 1.1  && < 1.6
                , text                 >= 2.0  && < 2.3
-               , optparse-applicative >= 0.16 && < 0.18
+               , optparse-applicative >= 0.16 && < 0.19
                , directory            >= 1.3  && < 1.4
                , unix-compat          >= 0.4  && < 0.8
                , process              >= 1.0  && < 1.7

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-21.4
+resolver: lts-22.22
 flags: {}
 packages:
   - "."

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    sha256: caa77fdbc5b9f698262b21ee78030133272ec53116ad6ddbefdc4c321f668e0c
-    size: 640014
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/4.yaml
-  original: lts-21.4
+    sha256: 4be1ca5d31689b524a7f0f17a439bbe9136465213edc498e9a395899a670f2aa
+    size: 718486
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/22.yaml
+  original: lts-22.22


### PR DESCRIPTION
# Description

This PR raises the stack resolver to LTS 22.22, and raises the upper bound on optparse-applicative in the cabal file